### PR TITLE
(docs) change opts to opt

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -52,7 +52,7 @@
 //	    out: gen
 //	  - local: protoc-gen-connect-go
 //	    out: gen
-//	    opts: package_suffix
+//	    opt: package_suffix
 //
 // This will generate output to:
 //


### PR DESCRIPTION
Change `opts` to `opt` in documentation for buf v2 schema.

Fixes https://github.com/connectrpc/connect-go/issues/815
